### PR TITLE
Add option to output only files that match a specified Google Keep "label"

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Works with Python 2 or 3
   The default format is Evernote
   
   Use the `--label` option to create an ouput directory containing only notes with the specified label
+  
+  Limited to one label for now
     
 **Module dependencies**:
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Works with Python 2 or 3
   Use the `--format` option to choose between Evernote and CintaNotes, for example, `--format CintaNotes`
   
   The default format is Evernote
+  
+  Use the `--label` option to create an ouput directory containing only notes with the specified label
     
 **Module dependencies**:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Works with Python 2 or 3
   
   Use the `--label` option to create an ouput directory containing only notes with the specified label
   
-  Limited to one label for now
+  Limited to one label and only the Evernote format for now
     
 **Module dependencies**:
 

--- a/keepToText.py
+++ b/keepToText.py
@@ -15,10 +15,17 @@ def htmlFileToText(inputPath, outputDir, tag, attrib, attribVal):
     basename = os.path.basename(inputPath).replace(".html", ".txt")
     outfname = os.path.join(outputDir, basename)
     try:
-        with codecs.open(inputPath, "r", "utf-8") as inf, codecs.open(outfname, "w", outputEncoding) as outf:
+        with codecs.open(inputPath, "r", "utf-8") as inf:
             html = inf.read()
-            parser = MyHTMLParser(outf, tag, attrib, attribVal)
-            parser.feed(html)
+            if args.label == None:
+                with codecs.open(outfname, "w", outputEncoding) as outf:
+                    parser = MyHTMLParser(outf, tag, attrib, attribVal)
+                    parser.feed(html)
+            else:
+                if '"label-name">' + args.label in html:
+                    with codecs.open(outfname, "w", outputEncoding) as outf:
+                        parser = MyHTMLParser(outf, tag, attrib, attribVal)
+                        parser.feed(html)
     except UnicodeEncodeError as ex:
         msg("Skipping file " + inputPath + ": " + str(ex))
     except LookupError as ex:
@@ -196,6 +203,8 @@ def getArgs():
         help="use the system encoding for the output")
     parser.add_argument("--format", choices=["Evernote", "CintaNotes"],
         default='Evernote', help="Output Format")
+    parser.add_argument("--label",
+        help="output only consists of notes with a specified label")
     global args
     args = parser.parse_args()    
 


### PR DESCRIPTION
Google Keep has a labels feature that's reflected by a "label-name" class in the HTML files. These changes let a user input a label name, creating in the "Text" directory only text files that match the label. Please see the limitations in the README. There are also no problems if a note is assigned multiple labels in Google Keep.